### PR TITLE
Add: support for sync reads

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,6 +23,9 @@ module.exports = (function() {
       });
     })
   }
+  function readBufSync(tgtImagePath) {
+    return fs.readFileSync(tgtImagePath);
+  }
   function readHexStr(bary, initIdx, length) {
     let line = '';
     for (let i = initIdx; i < (initIdx + length); i++) {
@@ -66,7 +69,7 @@ module.exports = (function() {
     const str = readHexStr(bary, 0, SIGNATURE_SIZE);
     return str === PNG_SIGNATURE;
   }
-  return function pngSizeReader(tgtImagePath) {
+  const returnFn = function pngSizeReader(tgtImagePath) {
     return new Promise((resolve, reject) => {
       readBuf(tgtImagePath).then((resp) => {
         if (check(resp)) {
@@ -79,4 +82,9 @@ module.exports = (function() {
       });
     });
   };
+  returnFn.sync = function pngSizeReaderSync(tgtImagePath) {
+    const buffer = readBufSync(tgtImagePath);
+    return analysis(buffer);
+  };
+  return returnFn;
 })();

--- a/test/test.js
+++ b/test/test.js
@@ -18,4 +18,19 @@ describe('png-size-reader test', () => {
       done();
     });
   });
+  it('test1-sync', (done) => {
+    const size = reader.sync(testPngFile);
+    assert(size[0] === 800);
+    assert(size[1] === 600);
+    done();
+  });
+  it('test2-sync', (done) => {
+    try{
+      const size = reader.sync(testJpgFile);
+      assert();
+    }catch (e) {
+      assert(e !== undefined);
+      done();
+    }
+  });
 });


### PR DESCRIPTION
Hi!
Thank you for your work on this useful module.

I'd like to contribute back with a synchronous function implementation, as it's useful to read and cache PNGs size at process start time without having to deal with async contexts.  